### PR TITLE
Upgrade to Node v20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,5 +30,5 @@ outputs:
   url:
     description: The URL of the Render service
 runs:
-  using: node16
+  using: node20
   main: dist/index.js


### PR DESCRIPTION
Node 16 is reaching [end-of-life](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) in Github Actions. This PR updates the node version, with no changes to the logic.